### PR TITLE
Improvements to Send Cash panel UI (3)

### DIFF
--- a/src/java/com/vaklinov/zcashui/DropdownComboBox.java
+++ b/src/java/com/vaklinov/zcashui/DropdownComboBox.java
@@ -1,0 +1,82 @@
+/************************************************************************************************
+ *   ____________ _   _  _____          _      _____ _    _ _______          __   _ _      _   
+ *  |___  /  ____| \ | |/ ____|        | |    / ____| |  | |_   _\ \        / /  | | |    | |  
+ *     / /| |__  |  \| | |     __ _ ___| |__ | |  __| |  | | | |  \ \  /\  / /_ _| | | ___| |_ 
+ *    / / |  __| | . ` | |    / _` / __| '_ \| | |_ | |  | | | |   \ \/  \/ / _` | | |/ _ \ __|
+ *   / /__| |____| |\  | |___| (_| \__ \ | | | |__| | |__| |_| |_   \  /\  / (_| | | |  __/ |_ 
+ *  /_____|______|_| \_|\_____\__,_|___/_| |_|\_____|\____/|_____|   \/  \/ \__,_|_|_|\___|\__|
+ *                                       
+ * Copyright (c) 2016-2018 The ZEN Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ **********************************************************************************/
+package com.vaklinov.zcashui;
+
+import javax.swing.JComboBox;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
+
+
+/**
+ * Combo Box that is aware of whether is is dropped down.
+ */
+public class DropdownComboBox<E> 
+    extends JComboBox<E>
+{
+    protected boolean isMenuDown;
+    
+    public DropdownComboBox(E[] list) 
+    {
+        super(list);
+        
+        this.isMenuDown = false;
+        this.initDownListener();
+    }    
+    
+    
+    public boolean isMenuDown()
+    {
+        return this.isMenuDown;
+    }
+    
+    
+    private void initDownListener()
+    {
+        this.addPopupMenuListener(new PopupMenuListener() 
+        {    
+            @Override
+            public void popupMenuWillBecomeVisible(PopupMenuEvent e) 
+            {
+                DropdownComboBox.this.isMenuDown = true;
+            }
+            
+            @Override
+            public void popupMenuWillBecomeInvisible(PopupMenuEvent e) 
+            {
+                DropdownComboBox.this.isMenuDown = false;
+            }
+            
+            @Override
+            public void popupMenuCanceled(PopupMenuEvent e) 
+            {
+                DropdownComboBox.this.isMenuDown = false;
+            }
+        });   
+    }    
+}

--- a/src/java/com/vaklinov/zcashui/SendCashPanel.java
+++ b/src/java/com/vaklinov/zcashui/SendCashPanel.java
@@ -372,7 +372,9 @@ public class SendCashPanel
 	private void sendCash()
 		throws WalletCallException, IOException, InterruptedException
 	{
-		if (balanceAddressCombo.getItemCount() <= 0)
+		if ((balanceAddressCombo.getItemCount() <= 0) ||
+			(this.lastAddressBalanceData == null)     || 
+			(this.lastAddressBalanceData.length <= 0))
 		{
 			JOptionPane.showMessageDialog(
 				SendCashPanel.this.getRootPane().getParent(), 

--- a/src/java/com/vaklinov/zcashui/SendCashPanel.java
+++ b/src/java/com/vaklinov/zcashui/SendCashPanel.java
@@ -87,7 +87,7 @@ public class SendCashPanel
 	private BackupTracker             backupTracker;
 	private LabelStorage labelStorage;
 	
-	private JComboBox  balanceAddressCombo     = null;
+	private DropdownComboBox  balanceAddressCombo     = null;
 	private JPanel     comboBoxParentPanel     = null;
 	private String[][] lastAddressBalanceData  = null;
 	private String[]   comboBoxItems           = null;
@@ -141,7 +141,7 @@ public class SendCashPanel
 		tempPanel.add(new JLabel(langUtil.getString("send.cash.panel.label.info")));
 		sendCashPanel.add(tempPanel);
 
-		balanceAddressCombo = new JComboBox<>(new String[] { "" });
+		balanceAddressCombo = new DropdownComboBox<>(new String[] { "" });
 		comboBoxParentPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
 		comboBoxParentPanel.add(balanceAddressCombo);
 		sendCashPanel.add(comboBoxParentPanel);
@@ -306,7 +306,6 @@ public class SendCashPanel
 			{
 				try
 				{
-					// TODO: if the user has opened the combo box - this closes it (maybe fix)
 					SendCashPanel.this.updateWalletAddressPositiveBalanceComboBox();
 				} catch (Exception ex)
 				{
@@ -755,6 +754,13 @@ public class SendCashPanel
 	private void updateWalletAddressPositiveBalanceComboBox()
 		throws WalletCallException, IOException, InterruptedException
 	{
+		// If the user has opened the combo box menu - skip update
+		if (this.balanceAddressCombo.isMenuDown())
+		{
+		    Log.info("Skipping refresh of available sending addresses - user menu is open...");
+		    return;
+		}
+		
 		String[][] newAddressBalanceData = this.addressBalanceGatheringThread.getLastData();
 		
 		// The data may be null if nothing is yet obtained
@@ -762,8 +768,6 @@ public class SendCashPanel
 		{
 			return;
 		}
-		
-		// TODO: Do not update if user has opened the combo box
 		
 		final int oldSelectedIndex = this.balanceAddressCombo.getSelectedIndex();
 		String originalSelectedAddress = null;
@@ -798,7 +802,7 @@ public class SendCashPanel
 		
 		final boolean isEnabled = this.balanceAddressCombo.isEnabled();
 		this.comboBoxParentPanel.remove(balanceAddressCombo);
-		balanceAddressCombo = new JComboBox<>(comboBoxItems);
+		balanceAddressCombo = new DropdownComboBox<>(comboBoxItems);
 		comboBoxParentPanel.add(balanceAddressCombo);
 		// We need to restore the previously selected address in the combo box
 		// The address count/order may have changed as a result of newly confirmed 

--- a/src/java/com/vaklinov/zcashui/SendCashPanel.java
+++ b/src/java/com/vaklinov/zcashui/SendCashPanel.java
@@ -766,14 +766,15 @@ public class SendCashPanel
 		String[][] newAddressBalanceData = this.addressBalanceGatheringThread.getLastData();
 		
 		// The data may be null if nothing is yet obtained
-		if ((newAddressBalanceData == null) || (newAddressBalanceData.length <= 0))
+		if (newAddressBalanceData == null)
 		{
 			return;
 		}
 		
 		final int oldSelectedIndex = this.balanceAddressCombo.getSelectedIndex();
 		String originalSelectedAddress = null;
-		if ((this.lastAddressBalanceData != null) && (this.lastAddressBalanceData.length > oldSelectedIndex) &&
+		if ((this.lastAddressBalanceData != null) && (this.lastAddressBalanceData.length > 0) &&
+			(this.lastAddressBalanceData.length > oldSelectedIndex) &&
 			(balanceAddressCombo.getItemCount() > 0) && (oldSelectedIndex >= 0))
 		{
 			originalSelectedAddress = this.lastAddressBalanceData[oldSelectedIndex][1];

--- a/src/java/com/vaklinov/zcashui/SendCashPanel.java
+++ b/src/java/com/vaklinov/zcashui/SendCashPanel.java
@@ -763,6 +763,15 @@ public class SendCashPanel
 			return;
 		}
 		
+		// TODO: Do not update if user has opened the combo box
+		
+		final int oldSelectedIndex = this.balanceAddressCombo.getSelectedIndex();
+		String originalSelectedAddress = null;
+		if ((this.lastAddressBalanceData != null) && (this.lastAddressBalanceData.length > oldSelectedIndex))
+		{
+			originalSelectedAddress = this.lastAddressBalanceData[oldSelectedIndex][1];
+		}
+		
 		lastAddressBalanceData = newAddressBalanceData;
 		
 		comboBoxItems = new String[lastAddressBalanceData.length];
@@ -787,16 +796,31 @@ public class SendCashPanel
 			comboBoxItems[i] = item;
 		}
 		
-		int selectedIndex = balanceAddressCombo.getSelectedIndex();
-		boolean isEnabled = balanceAddressCombo.isEnabled();
+		final boolean isEnabled = this.balanceAddressCombo.isEnabled();
 		this.comboBoxParentPanel.remove(balanceAddressCombo);
 		balanceAddressCombo = new JComboBox<>(comboBoxItems);
 		comboBoxParentPanel.add(balanceAddressCombo);
-		if ((balanceAddressCombo.getItemCount() > 0) &&
-			(selectedIndex >= 0) &&
-			(balanceAddressCombo.getItemCount() > selectedIndex))
+		// We need to restore the previously selected address in the combo box
+		// The address count/order may have changed as a result of newly confirmed 
+		// transactions, necessitating additional checks.
+		int newIndexToSelect = oldSelectedIndex; // By default index does not change
+		// Try to find the original selected address in the new data - its index may be different
+		// after the data was updated
+		for (int i = 0; i < this.lastAddressBalanceData.length; i++)
 		{
-			balanceAddressCombo.setSelectedIndex(selectedIndex);
+			String currentAddress = this.lastAddressBalanceData[i][1];
+			if ((currentAddress != null) && (originalSelectedAddress != null) &&
+				 currentAddress.trim().equalsIgnoreCase(originalSelectedAddress.trim()))
+			{
+				newIndexToSelect = i;
+			}
+		}
+		// Restore only the selected index - original address was not found
+		if ((balanceAddressCombo.getItemCount() > 0) &&
+			(newIndexToSelect >= 0) &&
+			(balanceAddressCombo.getItemCount() > newIndexToSelect))
+		{		
+			balanceAddressCombo.setSelectedIndex(newIndexToSelect);
 		}
 		balanceAddressCombo.setEnabled(isEnabled);
 

--- a/src/java/com/vaklinov/zcashui/SendCashPanel.java
+++ b/src/java/com/vaklinov/zcashui/SendCashPanel.java
@@ -764,14 +764,15 @@ public class SendCashPanel
 		String[][] newAddressBalanceData = this.addressBalanceGatheringThread.getLastData();
 		
 		// The data may be null if nothing is yet obtained
-		if (newAddressBalanceData == null)
+		if ((newAddressBalanceData == null) || (newAddressBalanceData.length <= 0))
 		{
 			return;
 		}
 		
 		final int oldSelectedIndex = this.balanceAddressCombo.getSelectedIndex();
 		String originalSelectedAddress = null;
-		if ((this.lastAddressBalanceData != null) && (this.lastAddressBalanceData.length > oldSelectedIndex))
+		if ((this.lastAddressBalanceData != null) && (this.lastAddressBalanceData.length > oldSelectedIndex) &&
+			(balanceAddressCombo.getItemCount() > 0) && (oldSelectedIndex >= 0))
 		{
 			originalSelectedAddress = this.lastAddressBalanceData[oldSelectedIndex][1];
 		}
@@ -819,7 +820,7 @@ public class SendCashPanel
 				newIndexToSelect = i;
 			}
 		}
-		// Restore only the selected index - original address was not found
+		// Restore only the selected index - original address was found (perhaps)
 		if ((balanceAddressCombo.getItemCount() > 0) &&
 			(newIndexToSelect >= 0) &&
 			(balanceAddressCombo.getItemCount() > newIndexToSelect))

--- a/src/java/com/vaklinov/zcashui/StartupProgressDialog.java
+++ b/src/java/com/vaklinov/zcashui/StartupProgressDialog.java
@@ -129,7 +129,11 @@ public class StartupProgressDialog extends JFrame {
             	info = clientCaller.getDaemonRawRuntimeInfo();
             } catch (IOException e)
             {
-            	if (iteration > 4)
+            	// We expect that within 20+ seconds the zend will at least show some signs of life
+            	// like being able to report that it is loading the block index etc.
+            	// So we have 15 iterations of 1.5 sec. of waiting. If after this time zend is not yet
+            	// there - we assume something is wrong and an error is reported.
+            	if (iteration > 15)
             	{
             		throw e;
             	} else


### PR DESCRIPTION
This is a follow-up to previously canceled pull requests:
#137 #140 

Contains two improvements in Send Cash UI panel:
1. When address list is updated, extra effort is made to make sure the address that was selected previously is still selected after update.
2. When the address drop down combo box is opened (down) no updates are made of the list so as not to disturb the user choice of address.

In addition the initial wait for zend to startup is increased - to prevent errors reported when zend takes too long to begin to respond via the RPC port.