### PR TITLE
Release 0.90.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,15 @@ before_deploy:
   - if [[ -z $TRAVIS_TAG ]]; then export TRAVIS_TAG=$TRAVIS_BRANCH; fi
 
 deploy:
+  edge: true
   provider: releases
   token: $GITHUB_AUTH
   file_glob: true
   file: "./releases/*"
-  skip_cleanup: true
+  cleanup: false
   overwrite: true
   draft: true
-  name: $READABLE_NAME
+  release_notes: $READABLE_NAME
   on:
     all_branches: true
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # [Horizen](https://horizen.global/) Desktop GUI Wallet
 
+<p align="center"><img src="https://www.horizen.global/assets/img/icons/page_media/logo_no_tagline.svg" width="600"></p>
+
+## Deprecation notice
+
+Horizen Desktop GUI Wallet will not receive any new features, future releases will be limited to critical bug fixes and compatibility with newer versions of zend.
+[Sphere by Horizen](https://github.com/ZencashOfficial/Sphere_by_Horizen) is its successor and ongoing development will be focused on Sphere by Horizen, to migrate to Sphere by Horizen please see our [wiki]( https://horizenofficial.atlassian.net/wiki/spaces/ZEN/pages/729776153).
+
+**Running Horizen Desktop GUI Wallet on macOS Catalina**: Horizen Desktop GUI Wallet is not going to be notarized and as such won't start on macOS Catalina without going through some extra steps, if you want to run it on MacOS Catalina please read and follow https://support.apple.com/en-us/HT202491 `How to open an app that hasn’t been notarized or is from an unidentified developer`.
+
 ## Graphical user interface wrapper for the [Horizen](https://horizen.global/) command line tools
 
 This program provides a Graphical User Interface (GUI) for the Horizen client tools that acts as a wrapper and 
@@ -27,7 +36,7 @@ presents the information in a user-friendly manner.
 
 #### New/Experimental: [Horizen Desktop GUI Wallet packages for Debian/Ubuntu Linux](https://github.com/ZencashOfficial/zencash-swing-wallet-ui/blob/master/docs/ReleaseUbuntuRepository.md) are available
 
-#### New/Experimental: [Horizen Desktop GUI Wallet for Windows/macOS](https://github.com/ZencashOfficial/zencash-swing-wallet-ui/blob/master/docs/Release_0.89.0.md) is available
+#### New/Experimental: [Horizen Desktop GUI Wallet for Windows/macOS](https://github.com/ZencashOfficial/zencash-swing-wallet-ui/blob/master/docs/Release_0.90.0.md) is available
 
 #### Information on diagnosing some common problems may be found in this [troubleshooting guide](docs/TroubleshootingGuide.md).
 

--- a/docs/Release_0.90.0.md
+++ b/docs/Release_0.90.0.md
@@ -1,0 +1,85 @@
+## [Horizen](https://horizen.global/) Desktop GUI Wallet binary release 0.90.0
+
+It includes [Horizen 2.0.21 binaries](https://github.com/ZencashOfficial/zen/releases/tag/v2.0.21). 
+
+**This wallet is targeted at advanced users who understand the implications of running a full Zen node on**
+**the local machine, maintaining a full local copy of the blockchain, maintaining and backing up the**
+**Zen nodes's `wallet.dat` file etc! The wallet is not suitable for novice crypto-currency users!**
+
+**SECURITY WARNING: Encryption of the wallet.dat file is not yet supported for Horizen. Using the wallet** 
+**on a system infected with malware may result in wallet data/funds being stolen. The**
+**wallet.dat needs to be backed up regularly (not just once - e.g. after every 30-40**
+**outgoing transactions) and it must also be backed up after creating a new Z address.**
+
+**STABILITY WARNING: The GUI wallet is as yet considered experimental! It is known to exhibit occasional stability problems related to running a full Zen node.**
+**Specifically if the locally running `zend` cannot start properly due to issues with the local blockchain, the GUI cannot start either!**
+**Users need to be prepared to fix such problems manually as described in the [troubleshooting guide](TroubleshootingGuide.md).**
+**Doing so requires command line skills.**
+
+**AUTO-DEPRECATION WARNING: Wallet binary releases for Mac/Windows contain ZEN full node binaries. These have an auto-deprecation feature:**
+**they are considered outdated after 16 weeks and stop working. So they need to be updated to a newer version before this term expires.**
+**Users need to ensure they use an up-to-date version of the wallet (e.g. update the wallet every two months or so).**
+
+### Installing the Horizen Desktop GUI Wallet on Windows
+
+It requires a 64-bit Windows 7 or later version to run.
+
+1. Download the Wallet EXE file
+[HorizenDesktopGUIWallet-0.90.0.exe](https://github.com/ZencashOfficial/zencash-swing-wallet-ui/releases/download/0.90.0/HorizenDesktopGUIWallet-0.90.0.exe).
+
+2. Security check: You may decide to run a virus scan on it, before proceeding... In addition using a tool 
+such as [http://quickhash-gui.org/](http://quickhash-gui.org/) you may calculate the its SHA256 checksum. The 
+result should be:
+```
+TODO  HorizenDesktopGUIWallet-0.90.0.exe
+```
+**If the resulting checksum is not `TODO` then**
+**something is wrong and you should discard the downloaded wallet!**
+
+3. Run the `HorizenDesktopGUIWallet-0.90.0.exe` installer and choose an installation folder.
+   
+### Running the Horizen Desktop GUI Wallet on Windows
+
+Double click on `HorizenDesktopGUIWallet.exe` in the installation folder or run `HorizenDesktopGUIWallet` from the start menu.
+On first run (only) the wallet will download the cryptographic keys (1.6GB or so).
+In case of problems logs are written in `%LOCALAPPDATA%\ZENCashSwingWalletUI\` for diagnostics.
+
+### Installing the Horizen Desktop GUI Wallet on Mac OS
+
+It requires Mac OS Sierra/High Sierra/Mojave.
+
+1. Download the Wallet image file
+[HorizenDesktopGUIWallet-0.90.0.dmg](https://github.com/ZencashOfficial/zencash-swing-wallet-ui/releases/download/0.90.0/HorizenDesktopGUIWallet-0.90.0.dmg).
+
+2. Security check: You may decide to run a virus scan on it before proceeding... In addition using a tool
+such as [http://quickhash-gui.org/](http://quickhash-gui.org/) you may calculate the its SHA256 checksum. The
+result should be:
+```
+TODO  HorizenDesktopGUIWallet-0.90.0.dmg
+```
+**If the resulting checksum is not `TODO` then**
+**something is wrong and you should discard the downloaded wallet!**
+
+3. Install the wallet like any other downloaded Mac OS application: Open the disk image `HorizenWallet-0.90.0.dmg`
+and copy the HorizenWallet application to the Applications folder. You can then discard the disk image.
+
+### Running the Horizen Desktop GUI Wallet on Mac OS
+
+Simply click on HorizenWallet in the Mac OS application launchpad.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+### Some known issues and limitations
+1. If a system has a high resolution monitor with DPI scaling enabled, not all GUI elements scale alike.
+As a result the Wallet UI may feel inconvenient to use at scaling above 1.5x or even unusable at scaling above 3x.
+This problem will be fixed in future versions.
+1. Limitation: The list of transactions does not show all outgoing ones (specifically outgoing Z address 
+transactions).  

--- a/installer/pom.xml
+++ b/installer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.zencash</groupId>
         <artifactId>HorizenSwingWalletUI</artifactId>
-        <version>0.89.0-SNAPSHOT</version>
+        <version>0.90.0-SNAPSHOT</version>
     </parent>
 
   <artifactId>installer</artifactId>

--- a/installer/src/main/izpack/install.xml
+++ b/installer/src/main/izpack/install.xml
@@ -2,7 +2,7 @@
 <installation version="5.0">
   <info>
     <appname>HorizenSwingWalletUI</appname>
-    <appversion>0.89.0</appversion>
+    <appversion>0.90.0</appversion>
     <url>https://horizen.global</url>
     <authors>
         <author name="Ivan Vaklinov" email="ivan@vaklinov.com"/>
@@ -47,7 +47,7 @@
   <variables>
     <variable name="InstallerFrame.logfilePath" value="Default"/>
     <variable name="WELCOME_TEXT" value="Horizen Swing Wallet Installation"/>
-    <variable name="WELCOME_VERSION" value="Version: 0.89.0"/>
+    <variable name="WELCOME_VERSION" value="Version: 0.90.0"/>
     <variable name="WELCOME_BG_COLOR" value="#404B62"/>
     <variable name="WELCOME_TEXT_COLOR" value="#ffffff"/>
   </variables>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.zencash</groupId>
     <artifactId>HorizenSwingWalletUI</artifactId>
-    <version>0.89.0-SNAPSHOT</version>
+    <version>0.90.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Horizen Swing Wallet UI</name>
 

--- a/src/build/build.xml
+++ b/src/build/build.xml
@@ -103,7 +103,7 @@
 	
     <target name="ubuntuPackage" depends="jar,copyothers">	
     	<mkdir dir="${ubuntu.package.dir}"/>
-	    <deb destfile="${ubuntu.package.dir}/zencash-desktop-gui-wallet_0.89.0_all.deb"
+	    <deb destfile="${ubuntu.package.dir}/zencash-desktop-gui-wallet_0.90.0_all.deb"
 	    	 control="${deb.dir}/control"
 	    	 verbose="true">
 	    	

--- a/src/resources/messages/zencash_en.properties
+++ b/src/resources/messages/zencash_en.properties
@@ -1,4 +1,4 @@
-main.frame.title=Horizen Desktop GUI Wallet 0.89.0
+main.frame.title=Horizen Desktop GUI Wallet 0.90.0
 main.frame.progressbar=Starting GUI wallet...
 main.frame.title.testnet=\u0020[using TESTNET]
 main.frame.tab.overview.title=Overview\u0020

--- a/src/resources/messages/zencash_it.properties
+++ b/src/resources/messages/zencash_it.properties
@@ -1,4 +1,4 @@
-main.frame.title=Horizen Desktop GUI Wallet 0.89.0
+main.frame.title=Horizen Desktop GUI Wallet 0.90.0
 main.frame.progressbar=Avviando la GUI...
 main.frame.title.testnet=\u0020[usando TESTNET]
 main.frame.tab.overview.title=Anteprima\u0020

--- a/zencash-wallet-swing/pom.xml
+++ b/zencash-wallet-swing/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.zencash</groupId>
         <artifactId>HorizenSwingWalletUI</artifactId>
-        <version>0.89.0-SNAPSHOT</version>
+        <version>0.90.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>zencash-wallet-swing</artifactId>

--- a/zencash-wallet-swing/src/deb/control/control
+++ b/zencash-wallet-swing/src/deb/control/control
@@ -1,5 +1,5 @@
 Package: zencash-desktop-gui-wallet
-Version: 0.89.0
+Version: 0.90.0
 Section: misc
 Priority: low
 Architecture: all


### PR DESCRIPTION
* CI updates for openjdk-14.0.1 DL path
* switched from deprecated CMC api to our own price api service
* Zend 2.0.21
* Bump Version to 0.90.0
* Add deprecation notice and instructions for macOS Catalina