### PR TITLE
Protect `readLine()` against DoS 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <source.version>1.8</source.version>
         <main.basedir>${project.basedir}</main.basedir>
+        <versions.java-security-toolkit>1.0.7</versions.java-security-toolkit>
     </properties>
 
     <licenses>
@@ -54,6 +55,11 @@
                 <groupId>com.eclipsesource.minimal-json</groupId>
                 <artifactId>minimal-json</artifactId>
                 <version>0.9.5</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.pixee</groupId>
+                <artifactId>java-security-toolkit</artifactId>
+                <version>${versions.java-security-toolkit}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -135,4 +141,10 @@
             </build>
         </profile>
     </profiles>
+    <dependencies>
+        <dependency>
+            <groupId>io.github.pixee</groupId>
+            <artifactId>java-security-toolkit</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/java/com/vaklinov/zcashui/AddressBookPanel.java
+++ b/src/java/com/vaklinov/zcashui/AddressBookPanel.java
@@ -2,6 +2,7 @@
 // Taken from repository https://github.com/zlatinb/zcash-swing-wallet-ui under an MIT licemse
 package com.vaklinov.zcashui;
 
+import io.github.pixee.security.BoundedLineReader;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.FlowLayout;
@@ -139,7 +140,7 @@ public class AddressBookPanel extends JPanel {
             return;
         try (BufferedReader bufferedReader = new BufferedReader(new FileReader(addressBookFile))) {
             String line;
-            while((line = bufferedReader.readLine()) != null) {
+            while((line = BoundedLineReader.readLine(bufferedReader, 5_000_000)) != null) {
                 // format is address,name - this way name can contain commas ;-)
                 int addressEnd = line.indexOf(',');
                 if (addressEnd < 0)

--- a/src/java/com/vaklinov/zcashui/CommandExecutor.java
+++ b/src/java/com/vaklinov/zcashui/CommandExecutor.java
@@ -29,6 +29,7 @@
 package com.vaklinov.zcashui;
 
 
+import io.github.pixee.security.SystemCommand;
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -53,7 +54,7 @@ public class CommandExecutor
 	public Process startChildProcess() 
 		throws IOException 
 	{
-	    return Runtime.getRuntime().exec(args);
+	    return SystemCommand.runCommand(Runtime.getRuntime(), args);
 	}
 	
 	
@@ -63,7 +64,7 @@ public class CommandExecutor
 		final StringBuffer result = new StringBuffer();
 		
 		Runtime rt = Runtime.getRuntime();
-		Process proc = rt.exec(args);
+		Process proc = SystemCommand.runCommand(rt, args);
 
 		final Reader in = new InputStreamReader(new BufferedInputStream(proc.getInputStream()));
 

--- a/src/java/com/vaklinov/zcashui/DashboardPanel.java
+++ b/src/java/com/vaklinov/zcashui/DashboardPanel.java
@@ -697,13 +697,13 @@ public class DashboardPanel
 			public int compare(String[] o1, String[] o2)
 			{
 				Date d1 = new Date(0);
-				if ((!o1[4].equals("N/A")) && (Util.isNumeric(o1[4])))
+				if ((!"N/A".equals(o1[4])) && (Util.isNumeric(o1[4])))
 				{
 					d1 = new Date(Long.valueOf(o1[4]).longValue() * 1000L);
 				}
 
 				Date d2 = new Date(0);
-				if (!o2[4].equals("N/A") && Util.isNumeric(o2[4]))
+				if (!"N/A".equals(o2[4]) && Util.isNumeric(o2[4]))
 				{
 					d2 = new Date(Long.valueOf(o2[4]).longValue() * 1000L);
 				}
@@ -724,22 +724,22 @@ public class DashboardPanel
 		for (String[] trans : allTransactions)
 		{
 			// Direction
-			if (trans[1].equals("receive"))
+			if ("receive".equals(trans[1]))
 			{
 				trans[1] = "\u21E8 IN";
-			} else if (trans[1].equals("send"))
+			} else if ("send".equals(trans[1]))
 			{
 				trans[1] = "\u21E6 OUT";
-			} else if (trans[1].equals("generate"))
+			} else if ("generate".equals(trans[1]))
 			{
 				trans[1] = "\u2692\u2699 MINED";
-			} else if (trans[1].equals("immature"))
+			} else if ("immature".equals(trans[1]))
 			{
 				trans[1] = "\u2696 Immature";
 			};
 
 			// Date
-			if ((!trans[4].equals("N/A")) && Util.isNumeric(trans[4]))
+			if ((!"N/A".equals(trans[4])) && Util.isNumeric(trans[4]))
 			{
 				trans[4] = new Date(Long.valueOf(trans[4]).longValue() * 1000L).toLocaleString();
 			}
@@ -762,7 +762,7 @@ public class DashboardPanel
 			// Confirmed?
 			try
 			{
-				boolean isConfirmed = !trans[2].trim().equals("0"); 
+				boolean isConfirmed = !"0".equals(trans[2].trim()); 
 				
 				trans[2] = isConfirmed ?
 						(langUtil.getString("panel.dashboard.table.transactions.confirmed.yes") + confirmedSymbol) :

--- a/src/java/com/vaklinov/zcashui/HorizenUI.java
+++ b/src/java/com/vaklinov/zcashui/HorizenUI.java
@@ -624,7 +624,7 @@ public class HorizenUI
 	            for (LookAndFeelInfo ui : UIManager.getInstalledLookAndFeels())
 	            {
 	            	Log.info("Available look and feel: " + ui.getName() + " " + ui.getClassName());
-	                if (ui.getName().equals("Nimbus"))
+	                if ("Nimbus".equals(ui.getName()))
 	                {
 	                	Log.info("Setting look and feel: {0}", ui.getClassName());
 	                    UIManager.setLookAndFeel(ui.getClassName());

--- a/src/java/com/vaklinov/zcashui/LanguageUtil.java
+++ b/src/java/com/vaklinov/zcashui/LanguageUtil.java
@@ -1,5 +1,6 @@
 package com.vaklinov.zcashui;
 
+import io.github.pixee.security.BoundedLineReader;
 import javax.swing.*;
 import java.io.*;
 import java.text.MessageFormat;
@@ -85,7 +86,7 @@ public class LanguageUtil {
             return DEFAULT_LOCALE;
         }
             BufferedReader bufferedReader = new BufferedReader(new FileReader(languagePrefsFile));
-            String country = bufferedReader.readLine().trim();
+            String country = BoundedLineReader.readLine(bufferedReader, 5_000_000).trim();
             bufferedReader.close();
             return supportedLocale.get(country);
         } catch (FileNotFoundException e) {

--- a/src/java/com/vaklinov/zcashui/TransactionsDetailPanel.java
+++ b/src/java/com/vaklinov/zcashui/TransactionsDetailPanel.java
@@ -246,13 +246,13 @@ public class TransactionsDetailPanel
 			public int compare(String[] o1, String[] o2)
 			{
 				Date d1 = new Date(0);
-				if ((!o1[4].equals("N/A")) && Util.isNumeric(o1[4]))
+				if ((!"N/A".equals(o1[4])) && Util.isNumeric(o1[4]))
 				{
 					d1 = new Date(Long.valueOf(o1[4]).longValue() * 1000L);
 				}
 
 				Date d2 = new Date(0);
-				if (!o2[4].equals("N/A") && Util.isNumeric(o2[4]))
+				if (!"N/A".equals(o2[4]) && Util.isNumeric(o2[4]))
 				{
 					d2 = new Date(Long.valueOf(o2[4]).longValue() * 1000L);
 				}
@@ -287,22 +287,22 @@ public class TransactionsDetailPanel
 		for (String[] trans : allTransactions)
 		{
 			// Direction
-			if (trans[1].equals("receive"))
+			if ("receive".equals(trans[1]))
 			{
 				trans[1] = "\u21E8 IN";
-			} else if (trans[1].equals("send"))
+			} else if ("send".equals(trans[1]))
 			{
 				trans[1] = "\u21E6 OUT";
-			} else if (trans[1].equals("generate"))
+			} else if ("generate".equals(trans[1]))
 			{
 				trans[1] = "\u2692\u2699 MINED";
-			} else if (trans[1].equals("immature"))
+			} else if ("immature".equals(trans[1]))
 			{
 				trans[1] = "\u2696 Immature";
 			};
 
 			// Date
-			if ((!trans[4].equals("N/A")) && Util.isNumeric(trans[4]))
+			if ((!"N/A".equals(trans[4])) && Util.isNumeric(trans[4]))
 			{
 				trans[4] = new Date(Long.valueOf(trans[4]).longValue() * 1000L).toLocaleString();
 			}
@@ -325,7 +325,7 @@ public class TransactionsDetailPanel
 			// Confirmed?
 			try
 			{
-				boolean isConfirmed = !trans[2].trim().equals("0"); 
+				boolean isConfirmed = !"0".equals(trans[2].trim()); 
 				
 				trans[2] = isConfirmed ? (langUtil.getString("transactions.detail.panel.yes", confirmed))
 									   : (langUtil.getString("transactions.detail.panel.no", notConfirmed));

--- a/src/java/com/vaklinov/zcashui/ZCashClientCaller.java
+++ b/src/java/com/vaklinov/zcashui/ZCashClientCaller.java
@@ -335,7 +335,7 @@ public class ZCashClientCaller
 		    		this.transactionConfirmations.clear();
 		    	}
 		    	String confirmations = this.transactionConfirmations.get(txID);
-		    	if ((confirmations == null) || confirmations.equals("0"))
+		    	if ((confirmations == null) || "0".equals(confirmations))
 		    	{
 		    		currentTransaction[2] = this.getWalletTransactionConfirmations(txID);
 		    		this.transactionConfirmations.put(txID, currentTransaction[2]);
@@ -860,7 +860,7 @@ public class ZCashClientCaller
 	    	wrapStringParameter(signature), 
 	    	wrapStringParameter(message));
 
-		return response.trim().equalsIgnoreCase("true");
+		return "true".equalsIgnoreCase(response.trim());
 	}
 
 
@@ -875,12 +875,12 @@ public class ZCashClientCaller
 
 		Log.info("Operation " + opID + " status is " + response + ".");
 
-		if (status.equalsIgnoreCase("success") ||
-			status.equalsIgnoreCase("error") ||
-			status.equalsIgnoreCase("failed"))
+		if ("success".equalsIgnoreCase(status) ||
+			"error".equalsIgnoreCase(status) ||
+			"failed".equalsIgnoreCase(status))
 		{
 			return true;
-		} else if (status.equalsIgnoreCase("executing") || status.equalsIgnoreCase("queued"))
+		} else if ("executing".equalsIgnoreCase(status) || "queued".equalsIgnoreCase(status))
 		{
 			return false;
 		} else
@@ -901,10 +901,10 @@ public class ZCashClientCaller
 
 		Log.info("Operation " + opID + " status is " + response + ".");
 
-		if (status.equalsIgnoreCase("success"))
+		if ("success".equalsIgnoreCase(status))
 		{
 			return true;
-		} else if (status.equalsIgnoreCase("error") || status.equalsIgnoreCase("failed"))
+		} else if ("error".equalsIgnoreCase(status) || "failed".equalsIgnoreCase(status))
 		{
 			return false;
 		} else

--- a/src/java/com/vaklinov/zcashui/ZendParametersEditDialog.java
+++ b/src/java/com/vaklinov/zcashui/ZendParametersEditDialog.java
@@ -382,7 +382,7 @@ public class ZendParametersEditDialog
 	{
 		String paramName = this.getParamName(fullParam);
 		 
-		return paramName.equals("addnode"); // For now only addnode seems to be a multi-occur option
+		return "addnode".equals(paramName); // For now only addnode seems to be a multi-occur option
 	}
 	
 	

--- a/src/java/com/vaklinov/zcashui/msg/MessagingPanel.java
+++ b/src/java/com/vaklinov/zcashui/msg/MessagingPanel.java
@@ -1593,7 +1593,7 @@ public class MessagingPanel
 		{
 			String memoHex = trans.getString("memo", "ERROR");
 			String transactionID = trans.getString("txid",  "ERROR");
-			if (!memoHex.equals("ERROR"))
+			if (!"ERROR".equals(memoHex))
 			{
 				String decodedMemo = Util.decodeHexMemo(memoHex);
 				JsonObject jsonMessage = null;


### PR DESCRIPTION
This change hardens all [`BufferedReader#readLine()`](https://docs.oracle.com/javase/8/docs/api/java/io/BufferedReader.html#readLine--) operations against memory exhaustion.

There is no way to call `readLine()` safely since it is, by its nature, a read that must be terminated by the stream provider. Furthermore, a stream of data provided by an untrusted source could lead to a denial of service attack, as attackers can provide an infinite stream of bytes until the process runs out of memory.

Fixing it is straightforward using an API which limits the amount of expected characters to some sane limit. This is what our changes look like:

```diff
+ import io.github.pixee.security.BoundedLineReader;
  ...
  BufferedReader reader = getReader();
- String line = reader.readLine(); // unlimited read, can lead to DoS
+ String line = BoundedLineReader.readLine(reader, 5_000_000); // limited to 5MB
```

<details>
  <summary>More reading</summary>

  * [https://vulncat.fortify.com/en/detail?id=desc.dataflow.abap.denial_of_service](https://vulncat.fortify.com/en/detail?id=desc.dataflow.abap.denial_of_service)
  * [https://cwe.mitre.org/data/definitions/400.html](https://cwe.mitre.org/data/definitions/400.html)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/installing/) (codemod ID: [pixee:java/limit-readline](https://docs.pixee.ai/codemods/java/pixee_java_limit-readline)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-zc%2Fzencash-swing-wallet-ui%7Cf6fefd6c2dd55f7c13b1ced43f1daa4626bbcd8c)

<!--{"type":"DRIP","codemod":"pixee:java/limit-readline"}-->